### PR TITLE
git: Fixed a bug on Windows where the version hashes have single quotes around them

### DIFF
--- a/src/vcstools/git.py
+++ b/src/vcstools/git.py
@@ -525,7 +525,7 @@ class GitClient(VcsClientBase):
                 cmd += " --pretty=format:%H"
             _, output, _ = run_shell_command(cmd, shell=True, cwd=self._path)
             for line in output.splitlines():
-                if line.startswith(version):
+                if line.strip("'").startswith(version):
                     return False
             return True
         return False

--- a/src/vcstools/vcs_base.py
+++ b/src/vcstools/vcs_base.py
@@ -122,7 +122,7 @@ class VcsClientBase(object):
         after a failed call to checkout, a repository still exists,
         e.g. if an invalid revision spec was given.
         If shallow is provided, the scm client may checkout less
-        than the full repository history to svae time / disk space.
+        than the full repository history to save time / disk space.
 
         :param url: where to checkout from
         :type url: str


### PR DESCRIPTION
On Windows, when updating a git repository, I get:

```
WARNING [vcstools] Command failed: 'git rev-list "remotes/origin/master" "^'c530eb2c4f07fffa5565dea70f29578f6b3df887" --parents'
 run at: 'C:\Users\Administrator\devel\groovy\base\catkin'
 errcode: 128:
fatal: bad revision '^'c530eb2c4f07fffa5565dea70f29578f6b3df887'
[/vcstools]
```

This is because of the single quotes around the version hash, so I added a `.strip("'")` in the get_version function.  Seems to fix the problem.  This is most likely the result of slightly different git outputs on Windows.
