### PR TITLE
Deprecate vcsclient

### DIFF
--- a/src/vcstools/vcs_abstraction.py
+++ b/src/vcstools/vcs_abstraction.py
@@ -44,6 +44,13 @@ def register_vcs(vcs_type, clazz):
     _VCS_TYPES[vcs_type] = clazz
 
 
+def get_registered_vcs_types():
+    """
+    :returns: list of valid key to use as vcs_type
+    """
+    return list(_VCS_TYPES.keys())
+
+
 def get_vcs(vcs_type):
     """
     Returns the class interfacing with vcs of given type

--- a/test/test_vcs_abstraction.py
+++ b/test/test_vcs_abstraction.py
@@ -1,0 +1,47 @@
+import unittest
+from mock import Mock
+
+import vcstools.vcs_abstraction
+from vcstools.vcs_abstraction import register_vcs, get_registered_vcs_types, \
+    get_vcs, get_vcs_client
+
+
+class TestVcsAbstraction(unittest.TestCase):
+
+    def test_register_vcs(self):
+        try:
+            backup = vcstools.vcs_abstraction._VCS_TYPES
+            vcstools.vcs_abstraction._VCS_TYPES = {}
+            self.assertEqual([], get_registered_vcs_types())
+            mock_class = Mock()
+            register_vcs('foo', mock_class)
+            self.assertEqual(['foo'], get_registered_vcs_types())
+        finally:
+            vcstools.vcs_abstraction._VCS_TYPES = backup
+
+    def test_get_vcs(self):
+        try:
+            backup = vcstools.vcs_abstraction._VCS_TYPES
+            vcstools.vcs_abstraction._VCS_TYPES = {}
+            self.assertEqual([], get_registered_vcs_types())
+            mock_class = Mock()
+            register_vcs('foo', mock_class)
+            self.assertEqual(mock_class, get_vcs('foo'))
+            self.assertRaises(ValueError, get_vcs, 'bar')
+        finally:
+            vcstools.vcs_abstraction._VCS_TYPES = backup
+
+    def test_get_vcs_client(self):
+        try:
+            backup = vcstools.vcs_abstraction._VCS_TYPES
+            vcstools.vcs_abstraction._VCS_TYPES = {}
+            self.assertEqual([], get_registered_vcs_types())
+            mock_class = Mock()
+            mock_instance = Mock()
+            # mock __init__ constructor
+            mock_class.return_value = mock_instance
+            register_vcs('foo', mock_class)
+            self.assertEqual(mock_instance, get_vcs_client('foo', 'foopath'))
+            self.assertRaises(ValueError, get_vcs_client, 'bar', 'barpath')
+        finally:
+            vcstools.vcs_abstraction._VCS_TYPES = backup


### PR DESCRIPTION
For review.

some small fixes around vcs_abstraction, now that it seems to get more attention.
One change is a bit serious, since I change the exception thrown for invalid keys from KeyError to ValueError. I don't think that it will break anything, I checked rosinstall unit tests to be sure.
