### PR TITLE
Get branches enhancement

### DIFF
--- a/src/vcstools/bzr.py
+++ b/src/vcstools/bzr.py
@@ -286,6 +286,14 @@ class BzrClient(VcsClientBase):
             response = response_processed
         return response
 
+    def get_branches(self, local_only=False):
+        # see http://doc.bazaar.canonical.com/beta/en/user-guide/shared_repository_layouts.html
+        # the 'bzr branches' command exists, but is not useful here (too many assumptions)
+        # Else bazaar branches are equivalent to forks in git and hg
+        # such branches (forks) on launchpad could be retrieved using
+        # the launchpadlib, but the API is probably not stable.
+        raise NotImplementedError("get_branches is not implemented for bzr")
+
     def export_repository(self, version, basepath):
         # execute the bzr export cmd
         cmd = 'bzr export --format=tgz {0} '.format(basepath + '.tar.gz')

--- a/src/vcstools/git.py
+++ b/src/vcstools/git.py
@@ -693,6 +693,22 @@ class GitClient(VcsClientBase):
             os.remove(basepath + '.tar')
         return True
 
+    def get_branches(self, local_only=False):
+        cmd = 'git branch --no-color'
+        if not local_only:
+            cmd += ' -a'
+        result, out, err = run_shell_command(cmd,
+                                             cwd=self._path,
+                                             shell=True,
+                                             show_stdout=False)
+        branches = []
+        for line in out.splitlines():
+            if 'HEAD -> ' in line:
+                continue
+            line = line.strip('* ')
+            branches.append(line)
+        return branches
+
     def _do_fetch(self, timeout=None):
         """
         calls git fetch

--- a/src/vcstools/hg.py
+++ b/src/vcstools/hg.py
@@ -346,6 +346,21 @@ class HgClient(VcsClientBase):
             os.remove(basepath + '.tar')
         return True
 
+    def get_branches(self, local_only=False):
+        if not local_only:
+            self._do_pull()
+        cmd = 'hg branches'
+        result, out, _ = run_shell_command(cmd, shell=True, cwd=self._path,
+                                           show_stdout=False)
+        if result:
+            return []
+        branches = []
+        for line in out.splitlines():
+            line = line.strip()
+            line = line.split()
+            branches.append(line[0])
+        return branches
+
     def _do_pull(self, filter=False):
         value, _, _ = run_shell_command("hg pull",
                                         cwd=self._path,

--- a/src/vcstools/vcs_abstraction.py
+++ b/src/vcstools/vcs_abstraction.py
@@ -140,5 +140,9 @@ class VcsClient(object):
     def export_repository(self, version, basepath):
         return self.vcs.export_repository(version, basepath)
 
+    def get_branches(self, local_only=False):
+        return self.vcs.get_branches(local_only)
+
+
 # backwards compat
 VCSClient = VcsClient

--- a/src/vcstools/vcs_base.py
+++ b/src/vcstools/vcs_base.py
@@ -283,3 +283,13 @@ class VcsClientBase(object):
         """
         raise NotImplementedError("Base class export_repository method must be overridden for client type %s " %
                                   self._vcs_type_name)
+
+    def get_branches(self, local_only=False):
+        """
+        Returns a list of all branches in the vcs repository.
+
+        :param local_only: if True it will only list local branches
+        :returns: list of branches in the repository, [] if none exist
+        """
+        raise NotImplementedError("Base class get_branches method must "
+                                  "be overridden")

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -859,6 +859,30 @@ class GitExportClientTest(GitClientTestSetups):
         self.assertFalse(os.path.exists(self.basepath_export))
 
 
+class GitGetBranchesClientTest(GitClientTestSetups):
+
+    @classmethod
+    def setUpClass(self):
+        GitClientTestSetups.setUpClass()
+
+    def tearDown(self):
+        pass
+
+    def testGetBranches(self):
+        client = GitClient(self.local_path)
+        client.checkout(self.remote_path)
+        self.assertEqual(client.get_branches(True), ['master'])
+        self.assertEqual(client.get_branches(),
+                         ['master', 'remotes/origin/master',
+                          'remotes/origin/test_branch'])
+        subprocess.check_call('git checkout test_branch', shell=True,
+                              cwd=self.local_path, stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE)
+        self.assertEqual(client.get_branches(True), ['master', 'test_branch'])
+        self.assertEqual(client.get_branches(),
+                         ['master', 'test_branch', 'remotes/origin/master',
+                          'remotes/origin/test_branch'])
+
 class GitTimeoutTest(unittest.TestCase):
 
     class MuteHandler(BaseRequestHandler):
@@ -882,6 +906,7 @@ class GitTimeoutTest(unittest.TestCase):
         url = 'ssh://test@127.0.0.1:{0}/test'.format(self.mute_port)
         client = GitClient(self.local_path)
         start = time.time()
+                          
         self.assertFalse(client.checkout(url, timeout=2.0))
         stop = time.time()
         self.assertTrue(stop - start > 1.9)

--- a/test/test_hg.py
+++ b/test/test_hg.py
@@ -395,3 +395,37 @@ class HGExportRepositoryClientTest(HGClientTestSetups):
         self.assertTrue(os.path.exists(self.basepath_export + '.tar.gz'))
         self.assertFalse(os.path.exists(self.basepath_export + '.tar'))
         self.assertFalse(os.path.exists(self.basepath_export))
+
+
+class HGGetBranchesClientTest(HGClientTestSetups):
+
+    @classmethod
+    def setUpClass(self):
+        HGClientTestSetups.setUpClass()
+        url = self.local_url
+        client = HgClient(self.local_path)
+        client.checkout(url)
+
+    def tearDown(self):
+        pass
+
+    def test_get_branches(self):
+        client = HgClient(self.local_path)
+        # Make a local branch
+        subprocess.check_call('hg branch test_branch2', shell=True,
+                              cwd=self.local_path, stdout=subprocess.PIPE)
+        subprocess.check_call('hg commit -m "Making test_branch2"', shell=True,
+                              cwd=self.local_path, stdout=subprocess.PIPE)
+        self.assertEqual(client.get_branches(), ['test_branch2', 'test_branch', 'default'])
+
+        # Make a remote branch
+        subprocess.check_call('hg branch remote_branch', shell=True,
+                              cwd=self.remote_path, stdout=subprocess.PIPE)
+        subprocess.check_call("touch fixed.txt", shell=True,
+                              cwd=self.remote_path)
+        subprocess.check_call("hg add fixed.txt", shell=True,
+                              cwd=self.remote_path)
+        subprocess.check_call("hg commit -m initial", shell=True,
+                              cwd=self.remote_path)
+        self.assertEqual(client.get_branches(local_only=True), ['test_branch2', 'test_branch', 'default'])
+        self.assertEqual(client.get_branches(), ['remote_branch', 'test_branch2', 'test_branch', 'default'])


### PR DESCRIPTION
For review:
This rebases and supercedes https://github.com/vcstools/vcstools/pull/11
William, I completely changed the way svn get_branches works, for you to confirm. A launchpadlib hack for bzr is thinkable but I don't think it is worth the trouble right now.

The svn util function for the canonical form could come in handy to implement branch switching in svn.