### PR TITLE
fix #41, get_vcs_client function part of vcstools module api,

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 
 - fix #45 sometimes commands run forever
 - fix #44 minor bug when checking out from repo with default branch not master
+- fix #41 improvedAPI, get_vcs_client function part of vcstools module
 
 0.1.26
 ------

--- a/src/vcstools/__init__.py
+++ b/src/vcstools/__init__.py
@@ -36,7 +36,8 @@ Library for tools that need to interact with ROS-support version control systems
 
 import logging
 
-from vcstools.vcs_abstraction import VcsClient, VCSClient, register_vcs
+from vcstools.vcs_abstraction import VcsClient, VCSClient, register_vcs, \
+    get_vcs_client
 
 from vcstools.svn import SvnClient
 from vcstools.bzr import BzrClient

--- a/src/vcstools/vcs_abstraction.py
+++ b/src/vcstools/vcs_abstraction.py
@@ -85,7 +85,7 @@ class VcsClient(object):
 
     def __init__(self, vcs_type, path):
         self._path = path
-        warnings.warn("Class VcsClient is deprecated, use get_vcs_client() instead")
+        warnings.warn("Class VcsClient is deprecated, use from vcstools import get_vcs_client; get_vcs_client() instead")
         self.vcs = get_vcs_client(vcs_type, path)
 
     def path_exists(self):

--- a/test/test_vcs_abstraction.py
+++ b/test/test_vcs_abstraction.py
@@ -3,8 +3,9 @@ from mock import Mock
 
 import vcstools.vcs_abstraction
 from vcstools.vcs_abstraction import register_vcs, get_registered_vcs_types, \
-    get_vcs, get_vcs_client
+    get_vcs
 
+from vcstools import get_vcs_client
 
 class TestVcsAbstraction(unittest.TestCase):
 


### PR DESCRIPTION
 better deprecation warning.

for review
