### PR TITLE
fix bug around assuming "master" to be default branch, see #43

### DIFF
--- a/src/vcstools/git.py
+++ b/src/vcstools/git.py
@@ -180,7 +180,9 @@ class GitClient(VcsClientBase):
             return False
 
         try:
-            if refname is not None and refname != "master":
+            # update to make sure we are on the right branch. Do not
+            # check for "master" here, as default branch could be anything
+            if refname is not None:
                 return self.update(refname, verbose=verbose)
             else:
                 return True


### PR DESCRIPTION
To reproduce bug, use a repo with a default branch != master, yet specify "master" as version explicitly, e.g.
- git: {local-name: ant, uri: 'git://github.com/apache/ant.git', version: 'master'}

Result after rosws call: local client checked out with "trunk" branch, and no error message that no master exists. Should instead give that error (or be on master branch)
