### PR TITLE
run_shell_command blocking forever

### DIFF
--- a/src/vcstools/common.py
+++ b/src/vcstools/common.py
@@ -141,8 +141,8 @@ def run_shell_command(cmd, cwd=None, shell=False, us_env=True, show_stdout=False
             # it listen to the pipe, print and stores result in buffer for returning
             # this allows proc to run while we still can filter out output we don't care about
             # readline() blocks
-            while True:
-                line = proc.stdout.readline().decode('UTF-8')
+            for line in iter(proc.stdout.readline, b''):
+                line = line.decode('UTF-8')
                 if line is not None and line != '':
                     if verbose or not _discard_line(line):
                         print(line),
@@ -151,13 +151,13 @@ def run_shell_command(cmd, cwd=None, shell=False, us_env=True, show_stdout=False
                     break
         # stderr was swallowed in pipe, in verbose mode print lines
         if verbose:
-            while True:
-                line = proc.stderr.readline().decode('UTF-8')
+            for line in iter(proc.stderr.readline, b''):
+                line = line.decode('UTF-8')
                 if line != '':
                     print(line),
                     stderr_buf.append(line)
                 if not line:
-                    break    
+                    break
             
         (stdout, stderr) = proc.communicate()
         if stdout is not None:


### PR DESCRIPTION
When I was building some utility scripts, I kept running into problems with the git fetcher where it would block forever on fetching a repository.  It was blocking on the readline() when I am pretty sure the git command was actually complete.  Switching to this method for retrieving the lines seems to fix it.  

It's also the method suggested by [a stackoverflow quesiton with a similar problem](http://stackoverflow.com/a/12471855/9805).  The question seems to indicate that this might happen if the called program finishes before the readline() starts.
