### PR TITLE
provide wrapped calls to urlopen and urlretrieve that use netrc as fallback

### DIFF
--- a/src/vcstools/tar.py
+++ b/src/vcstools/tar.py
@@ -47,21 +47,7 @@ import tarfile
 import sys
 import yaml
 from vcstools.vcs_base import VcsClientBase, VcsError
-from vcstools.common import ensure_dir_notexists
-
-# first try python3, then python2
-try:
-    from urllib.request import urlretrieve
-except ImportError:
-    # from urllib import urlretrieve # malfunctions behind proxy
-    import urllib2
-    def urlretrieve(url):
-        fdesc, fname = tempfile.mkstemp() # Make a temporary file
-        fhand = os.fdopen(fdesc, "w")
-        resp = urllib2.urlopen(url)
-        shutil.copyfileobj(resp.fp, fhand) # Copy the http response to the temporary file.
-        return (fname, resp.headers)
-
+from vcstools.common import urlretrieve_netrc, ensure_dir_notexists
 
 
 __pychecker__ = 'unusednames=spec'
@@ -117,7 +103,7 @@ class TarClient(VcsClientBase):
             if os.path.isfile(url):
                 filename = url
             else:
-                (filename, _) = urlretrieve(url)
+                (filename, _) = urlretrieve_netrc(url)
                 # print "filename", filename
             temp_tarfile = tarfile.open(filename, 'r:*')
             members = None # means all members in extractall

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -3,9 +3,15 @@ import os
 import sys
 import io
 import unittest
+import tempfile
+import shutil
+from mock import Mock
 
+import vcstools
 from vcstools.vcs_base import VcsClientBase, VcsError
-from vcstools.common import sanitized, normalized_rel_path, run_shell_command
+from vcstools.common import sanitized, normalized_rel_path, \
+    run_shell_command, urlretrieve_netrc, _netrc_open, urlopen_netrc
+
 
 class BaseTest(unittest.TestCase):
 
@@ -77,3 +83,79 @@ class BaseTest(unittest.TestCase):
         run_shell_command("echo %s"%(b'\xc3\xa4'.decode('UTF-8')), shell=True, verbose=True)
         run_shell_command(["echo", b'\xc3\xa4'.decode('UTF-8')], verbose=True)
 
+    def test_netrc_open(self):
+        root_directory = tempfile.mkdtemp()
+        machine = 'foo.org'
+        uri = 'https://%s/bim/bam' % machine
+        netrcname = os.path.join(root_directory, "netrc")
+        mock_build_opener = Mock()
+        mock_build_opener_fun = Mock()
+        mock_build_opener_fun.return_value = mock_build_opener
+        back_build_opener = vcstools.common.build_opener
+        try:
+            vcstools.common.build_opener = mock_build_opener_fun
+            filelike = _netrc_open(uri, netrcname)
+            self.assertFalse(filelike)
+
+            with open(netrcname, 'w') as fhand:
+                fhand.write(
+                    'machine %s login fooname password foopass' % machine)
+            filelike = _netrc_open(uri, netrcname)
+            self.assertTrue(filelike)
+            filelike = _netrc_open('other', netrcname)
+            self.assertFalse(filelike)
+            filelike = _netrc_open(None, netrcname)
+            self.assertFalse(filelike)
+        finally:
+            shutil.rmtree(root_directory)
+            vcstools.common.build_opener = back_build_opener
+
+    def test_urlopen_netrc(self):
+        mockopen = Mock()
+        mock_result = Mock()
+        backopen = vcstools.common.urlopen
+        backget = vcstools.common._netrc_open
+        try:
+            #monkey-patch with mocks
+            vcstools.common.urlopen = mockopen
+            vcstools.common._netrc_open = Mock()
+            vcstools.common._netrc_open.return_value = mock_result
+            ioe = IOError('MockError')
+            mockopen.side_effect = ioe
+            self.assertRaises(IOError, urlopen_netrc, 'foo')
+            ioe.code = 401
+            result = urlopen_netrc('foo')
+            self.assertEqual(mock_result, result)
+        finally:
+            vcstools.common.urlopen = backopen
+            vcstools.common._netrc_open = backget
+
+    def test_urlretrieve_netrc(self):
+        root_directory = tempfile.mkdtemp()
+        examplename = os.path.join(root_directory, "foo")
+        outname = os.path.join(root_directory, "fooout")
+        with open(examplename, "w") as fhand:
+            fhand.write('content')
+        mockget = Mock()
+        mockopen = Mock()
+        mock_fhand = Mock()
+        backopen = vcstools.common.urlopen
+        backget = vcstools.common._netrc_open
+        try:
+            # vcstools.common.urlopen = mockopen
+            # vcstools.common.urlopen.return_value = mock_fhand
+            # mock_fhand.read.return_value = 'content'
+            mockopen.open.return_value
+            vcstools.common._netrc_open = Mock()
+            vcstools.common._netrc_open.return_value = mockget
+            (fname, headers) = urlretrieve_netrc('file://' + examplename)
+            self.assertTrue(fname)
+            self.assertFalse(os.path.exists(outname))
+            (fname, headers) = urlretrieve_netrc('file://' + examplename,
+                                                 outname)
+            self.assertEqual(outname, fname)
+            self.assertTrue(os.path.isfile(outname))
+        finally:
+            vcstools.common.urlopen = backopen
+            vcstools.common._netrc_open = backget
+            shutil.rmtree(root_directory)


### PR DESCRIPTION
For review.

netrc is a protocoll where users have a .netrc file intheir home that stores credentials used e.g. for ftp, but are also used automatically e.g. by git.

Extracted code from
https://github.com/vcstools/rosinstall/pull/70
to vcstools, as we can use it well there too. Should help fixing:
https://github.com/vcstools/wstool/issues/8

Also cleaned up functions, refactored and commented more, and provided unit tests for each.
