### PR TITLE
More fixes for #62

### DIFF
--- a/src/vcstools/bzr.py
+++ b/src/vcstools/bzr.py
@@ -49,7 +49,8 @@ except ImportError:
     from urllib2 import url2pathname
 
 from vcstools.vcs_base import VcsClientBase, VcsError
-from vcstools.common import sanitized, normalized_rel_path, run_shell_command
+from vcstools.common import sanitized, normalized_rel_path, \
+    run_shell_command, ensure_dir_notexists
 
 
 def _get_bzr_version():
@@ -130,6 +131,10 @@ class BzrClient(VcsClientBase):
     def checkout(self, url, version=None, verbose=False, shallow=False):
         if url is None or url.strip() == '':
             raise ValueError('Invalid empty url : "%s"' % url)
+        # bzr 2.5.1 fails if empty directory exists
+        if not ensure_dir_notexists(self.get_path()):
+            self.logger.error("Can't remove %s" % self.get_path())
+            return False
         cmd = 'bzr branch'
         if version:
             cmd += ' -r %s' % version

--- a/src/vcstools/common.py
+++ b/src/vcstools/common.py
@@ -30,7 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-
+import errno
 import os
 import copy
 import shlex
@@ -38,6 +38,23 @@ import subprocess
 import logging
 
 from vcstools.vcs_base import VcsError
+
+
+def ensure_dir_notexists(path):
+    """
+    helper function, removes dir if it exists
+
+    :returns: True if dir does not exist after this function
+    :raises: OSError if dir exists and removal failed for non-trivial reasons
+    """
+    try:
+        if os.path.exists(path):
+            os.rmdir(path)
+        return True
+    except OSError as ose:
+        # ignore if directory
+        if not ose.errno in [errno.ENOENT, errno.ENOTEMPTY, errno.ENOTDIR]:
+            return False
 
 def normalized_rel_path(path, basepath):
     """

--- a/src/vcstools/svn.py
+++ b/src/vcstools/svn.py
@@ -44,7 +44,8 @@ import dateutil.parser  # For parsing date strings
 import xml.dom.minidom  # For parsing logfiles
 
 from vcstools.vcs_base import VcsClientBase, VcsError
-from vcstools.common import sanitized, normalized_rel_path, run_shell_command
+from vcstools.common import sanitized, normalized_rel_path, \
+    run_shell_command, ensure_dir_notexists
 
 
 def _get_svn_version():
@@ -105,10 +106,9 @@ class SvnClient(VcsClientBase):
     def checkout(self, url, version='', verbose=False, shallow=False):
         if url is None or url.strip() == '':
             raise ValueError('Invalid empty url : "%s"' % url)
-        # Need to check as SVN does not care
-        if self.path_exists():
-            sys.stderr.write("Error: cannot checkout into existing "
-                           + "directory %s\n" % self._path)
+        # Need to check as SVN 1.6.17 writes into directory even if not empty
+        if not ensure_dir_notexists(self.get_path()):
+            self.logger.error("Can't remove %s" % self.get_path())
             return False
         if version is not None and version != '':
             if not version.startswith("-r"):

--- a/src/vcstools/tar.py
+++ b/src/vcstools/tar.py
@@ -46,6 +46,7 @@ import tarfile
 import sys
 import yaml
 from vcstools.vcs_base import VcsClientBase, VcsError
+from vcstools.common import ensure_dir_notexists
 
 # first try python3, then python2
 try:
@@ -105,8 +106,8 @@ class TarClient(VcsClientBase):
         checkout named *.tar which is a yaml file listing origin url
         and version arguments.
         """
-        if self.path_exists():
-            self.logger.error("Cannot checkout into existing directory")
+        if not ensure_dir_notexists(self.get_path()):
+            self.logger.error("Can't remove %s" % self.get_path())
             return False
         tempdir = None
         result = False

--- a/src/vcstools/vcs_base.py
+++ b/src/vcstools/vcs_base.py
@@ -128,8 +128,8 @@ class VcsClientBase(object):
     def checkout(self, url, spec=None, verbose=False, shallow=False):
         """
         Attempts to create a local repository given a remote
-        url. Fails if a directory exists already in target
-        location. If a spec is provided, the local repository
+        url. Fails if a target path exists, unless it's an empty directory.
+        If a spec is provided, the local repository
         will be updated to that revision. It is possible that
         after a failed call to checkout, a repository still exists,
         e.g. if an invalid revision spec was given.

--- a/test/test_bzr.py
+++ b/test/test_bzr.py
@@ -186,6 +186,15 @@ class BzrClientTest(BzrClientTestSetups):
         self.assertEqual(client.get_path(), self.local_path)
         self.assertEqual(client.get_url(), url)
 
+    def test_checkout_dir_exists(self):
+        url = self.remote_path
+        client = BzrClient(self.local_path)
+        self.assertFalse(client.path_exists())
+        os.makedirs(self.local_path)
+        self.assertTrue(client.checkout(url))
+        # non-empty
+        self.assertFalse(client.checkout(url))
+
     def test_checkout_specific_version_and_update(self):
         url = self.remote_path
         version = "1"

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -139,6 +139,15 @@ class GitClientTest(GitClientTestSetups):
         self.assertEqual(client.get_branch_parent(), "master")
         #self.assertEqual(client.get_version(), '-r*')
 
+    def test_checkout_dir_exists(self):
+        url = self.remote_path
+        client = GitClient(self.local_path)
+        self.assertFalse(client.path_exists())
+        os.makedirs(self.local_path)
+        self.assertTrue(client.checkout(url))
+        # non-empty
+        self.assertFalse(client.checkout(url))
+
     def test_checkout_no_unnecessary_updates(self):
         client = GitClient(self.local_path)
         client.fetches = 0

--- a/test/test_hg.py
+++ b/test/test_hg.py
@@ -127,6 +127,15 @@ class HGClientTest(HGClientTestSetups):
         self.assertEqual(client.get_url(), url)
         self.assertEqual(client.get_version(), self.local_version)
 
+    def test_checkout_dir_exists(self):
+        url = self.remote_path
+        client = HgClient(self.local_path)
+        self.assertFalse(client.path_exists())
+        os.makedirs(self.local_path)
+        self.assertTrue(client.checkout(url))
+        # non-empty
+        self.assertFalse(client.checkout(url))
+
     def test_checkout_emptystringversion(self):
         # special test to check that version '' means the same as None
         url = self.local_url

--- a/test/test_svn.py
+++ b/test/test_svn.py
@@ -139,6 +139,15 @@ class SvnClientTest(SvnClientTestSetups):
         self.assertEqual(client.get_path(), self.local_path)
         self.assertEqual(client.get_url(), url)
 
+    def test_checkout_dir_exists(self):
+        url = self.local_url
+        client = SvnClient(self.local_path)
+        self.assertFalse(client.path_exists())
+        os.makedirs(self.local_path)
+        self.assertTrue(client.checkout(url))
+        # non-empty
+        self.assertFalse(client.checkout(url))
+
     def test_checkout_emptyversion(self):
         url = self.local_url
         client = SvnClient(self.local_path)

--- a/test/test_tar.py
+++ b/test/test_tar.py
@@ -100,6 +100,17 @@ class TarClientTest(unittest.TestCase):
                                                     self.package_version,
                                                     'stack.xml')))
 
+    def test_checkout_dir_exists(self):
+        directory = tempfile.mkdtemp()
+        self.directories["checkout_test"] = directory
+        local_path = os.path.join(directory, "exploration")
+        client = TarClient(local_path)
+        self.assertFalse(client.path_exists())
+        os.makedirs(local_path)
+        self.assertTrue(client.checkout(self.remote_url))
+        # non-empty
+        self.assertFalse(client.checkout(self.remote_url))
+
     def test_checkout_version(self):
         directory = tempfile.mkdtemp()
         self.directories["checkout_test"] = directory


### PR DESCRIPTION
Ensure all clients handle existing empty or non-empty folder the same way.
If folder exists and is empty, checkout shall succeed now.
git and mercurial behave nicely anyway, only unit tests added.

BZR and tar clients had to be changed to remove empty folder before checkout attempt.
SVN changed to only fail for non-empty folders
