### PR TITLE
fix #75

### DIFF
--- a/src/vcstools/git.py
+++ b/src/vcstools/git.py
@@ -174,7 +174,10 @@ class GitClient(VcsClientBase):
             cmd += ' --depth 1'
             if LooseVersion(self.gitversion) >= LooseVersion('1.7.10'):
                 cmd += ' --no-single-branch'
-        cmd += ' --recursive %s %s' % (url, self._path)
+        if refname is None:
+            # quicker than using _do_update, but undesired when switching branches next
+            cmd += ' --recursive'
+        cmd += ' %s %s' % (url, self._path)
         value, _, msg = run_shell_command(cmd,
                                           shell=True,
                                           no_filter=True,


### PR DESCRIPTION
 makes sure cloning a branch with submodules only fetches the submodules of that branch (not the default)

Actually, this makes some difference in the filesystem, as if git checks out submodules of the default branch first, the files linger around when switching branches, even if those submodules are not part of the new branch.
