### PR TITLE
missing dependency to python-dateutil

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,4 @@
 [DEFAULT]
-Depends: subversion, mercurial, git-core, bzr, python-yaml
+Depends: subversion, mercurial, git-core, bzr, python-yaml, python-dateutil
 Suite: lucid oneiric precise quantal raring wheezy
 XS-Python-Version: >= 2.6


### PR DESCRIPTION
Looking through old branches, I noticed this dependency seems to be missing for packaging
