### PR TITLE
removelong obsolete force-fetch param

### DIFF
--- a/src/vcstools/git.py
+++ b/src/vcstools/git.py
@@ -214,7 +214,7 @@ class GitClient(VcsClientBase):
                 return False
         return True
 
-    def update(self, refname=None, verbose=False, force_fetch=False):
+    def update(self, refname=None, verbose=False):
         """
         if refname is None, attempts fast-forwarding current branch, if any.
 


### PR DESCRIPTION
Finally undo the silly workaround introduced in https://github.com/vcstools/vcstools/issues/37.

merge this if the buildfarm was finally restored to sanity.
