### PR TITLE
updating version querying method

### DIFF
--- a/src/vcstools/tar.py
+++ b/src/vcstools/tar.py
@@ -67,7 +67,7 @@ class TarClient(VcsClientBase):
     @staticmethod
     def get_environment_metadata():
         metadict = {}
-        metadict["version"] = 'tarfile version: %s' % tarfile.__version__
+        metadict["version"] = 'tarfile version: %s' % tarfile.version
         return metadict
 
     def get_url(self):

--- a/test/test_bzr.py
+++ b/test/test_bzr.py
@@ -220,6 +220,14 @@ class BzrClientTest(BzrClientTestSetups):
         client = BzrClient(self.remote_path)
         self.assertEquals('', client.get_status())
 
+    def test_get_environment_metadata(self):
+        # Verify that metadata is generated
+        directory = tempfile.mkdtemp()
+        self.directories['local'] = directory
+        local_path = os.path.join(directory, "local")
+        client = BzrClient(local_path)
+        self.assertTrue('version' in client.get_environment_metadata())
+
 
 class BzrClientLogTest(BzrClientTestSetups):
 

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -357,6 +357,14 @@ class GitClientTest(GitClientTestSetups):
         client = GitClient(self.remote_path)
         self.assertEquals('', client.get_status())
 
+    def test_get_environment_metadata(self):
+        # Verify that metadata is generated
+        directory = tempfile.mkdtemp()
+        self.directories['local'] = directory
+        local_path = os.path.join(directory, "local")
+        client = GitClient(local_path)
+        self.assertTrue('version' in client.get_environment_metadata())
+
 
 class GitClientUpdateTest(GitClientTestSetups):
 

--- a/test/test_hg.py
+++ b/test/test_hg.py
@@ -191,6 +191,14 @@ class HGClientTest(HGClientTestSetups):
         client = HgClient(self.remote_path)
         self.assertEquals('', client.get_status())
 
+    def test_get_environment_metadata(self):
+        # Verify that metadata is generated
+        directory = tempfile.mkdtemp()
+        self.directories['local'] = directory
+        local_path = os.path.join(directory, "local")
+        client = HgClient(local_path)
+        self.assertTrue('version' in client.get_environment_metadata())
+
 
 class HGClientLogTest(HGClientTestSetups):
 

--- a/test/test_svn.py
+++ b/test/test_svn.py
@@ -184,6 +184,14 @@ class SvnClientTest(SvnClientTestSetups):
         client = SvnClient(self.remote_path)
         self.assertEquals('', client.get_status())
 
+    def test_get_environment_metadata(self):
+        # Verify that metadata is generated
+        directory = tempfile.mkdtemp()
+        self.directories['local'] = directory
+        local_path = os.path.join(directory, "local")
+        client = SvnClient(local_path)
+        self.assertTrue('version' in client.get_environment_metadata())
+
 
 class SvnClientLogTest(SvnClientTestSetups):
 

--- a/test/test_tar.py
+++ b/test/test_tar.py
@@ -128,6 +128,14 @@ class TarClientTest(unittest.TestCase):
         # make sure the tarball subdirectory was promoted correctly.
         self.assertTrue(os.path.exists(os.path.join(local_path, 'stack.xml')))
 
+    def test_get_environment_metadata(self):
+        # Verify that metadata is generated
+        directory = tempfile.mkdtemp()
+        self.directories['local'] = directory
+        local_path = os.path.join(directory, "local")
+        client = TarClient(local_path)
+        self.assertTrue('version' in client.get_environment_metadata())
+
 
 class TarClientTestLocal(unittest.TestCase):
 


### PR DESCRIPTION
Also add unit tests for coverage of this metadata queries for each vcs. 

tarfile.**version** is not available in python 3.3
