### PR TITLE
Optimization: provide static detect presense method to avoid Client init

### DIFF
--- a/src/vcstools/bzr.py
+++ b/src/vcstools/bzr.py
@@ -129,8 +129,9 @@ class BzrClient(VcsClientBase):
                                 break
         return result
 
-    def detect_presence(self):
-        return self.path_exists() and os.path.isdir(os.path.join(self._path, '.bzr'))
+    @staticmethod
+    def static_detect_presence(path):
+        return os.path.isdir(os.path.join(path, '.bzr'))
 
     def checkout(self, url, version=None, verbose=False, shallow=False):
         if url is None or url.strip() == '':

--- a/src/vcstools/git.py
+++ b/src/vcstools/git.py
@@ -156,11 +156,12 @@ class GitClient(VcsClientBase):
             return output.rstrip()
         return None
 
-    def detect_presence(self):
+    @staticmethod
+    def static_detect_presence(path):
         # There is a proposed implementation of detect_presence which might be
         # more future proof, but would depend on parsing the output of git
         # See: https://github.com/vcstools/vcstools/pull/10
-        return self.path_exists() and os.path.exists(os.path.join(self._path, '.git'))
+        return os.path.exists(os.path.join(path, '.git'))
 
     def checkout(self, url, version=None, verbose=False, shallow=False):
         """calls git clone and then, if version was given, update(version)"""

--- a/src/vcstools/hg.py
+++ b/src/vcstools/hg.py
@@ -138,9 +138,9 @@ class HgClient(VcsClientBase):
             return output.rstrip()
         return None
 
-    def detect_presence(self):
-        return (self.path_exists() and
-                os.path.isdir(os.path.join(self._path, '.hg')))
+    @staticmethod
+    def static_detect_presence(path):
+        return os.path.isdir(os.path.join(path, '.hg'))
 
     def checkout(self, url, version='', verbose=False, shallow=False):
         if url is None or url.strip() == '':

--- a/src/vcstools/svn.py
+++ b/src/vcstools/svn.py
@@ -100,9 +100,9 @@ class SvnClient(VcsClientBase):
             if matches:
                 return matches[0][5:]
 
-    def detect_presence(self):
-        return self.path_exists() and \
-            os.path.isdir(os.path.join(self.get_path(), '.svn'))
+    @staticmethod
+    def static_detect_presence(path):
+        return os.path.isdir(os.path.join(path, '.svn'))
 
     def checkout(self, url, version='', verbose=False, shallow=False):
         if url is None or url.strip() == '':

--- a/src/vcstools/tar.py
+++ b/src/vcstools/tar.py
@@ -82,8 +82,9 @@ class TarClient(VcsClientBase):
                     return metadata['url']
         return None
 
-    def detect_presence(self):
-        return self.path_exists() and os.path.exists(self.metadata_path)
+    @staticmethod
+    def static_detect_presence(path):
+        return os.path.isfile(os.path.join(path, _METADATA_FILENAME))
 
     def checkout(self, url, version='', verbose=False, shallow=False):
         """

--- a/src/vcstools/vcs_base.py
+++ b/src/vcstools/vcs_base.py
@@ -167,10 +167,16 @@ class VcsClientBase(object):
         raise NotImplementedError("Base class update method must be overridden for client type %s " %
                                   self._vcs_type_name)
 
-    def detect_presence(self):
+    @staticmethod
+    def static_detect_presence(path):
         """For auto detection"""
         raise NotImplementedError(
             "Base class detect_presence method must be overridden")
+
+    def detect_presence(self):
+        """For auto detection"""
+        #call static method
+        return self.static_detect_presence(self._path)
 
     def get_vcs_type_name(self):
         """ used when auto detected """


### PR DESCRIPTION
Also removes redundant call to os.path.exist(parentdir)

Explanation: currently vcstools does not offer to detect the presence of a vcs without initializing a vcsclient, which always implies a shell command and thus wastes time. With this change, clients can instead call a static method to decide whether they need a client in the first place.

wstool has to be adapted later to use this changed API for a slight speed benefit, see wstool/src/wstool/conf_element.py:AVCSConfigElement
