### PR TITLE
add apt-get update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   # precise
   - HG='2.0.2' BZR=2.5.0 GIT=v1.7.9.5 SVN=1.6.17 PYYAML=3.10
   # quantal
-  - HG='2.2.2' BZR=2.6.0~beta2 GIT=v1.7.10.4 SVN=1.7.5 PYYAML=3.10
+  - HG='2.2.2' BZR=2.6.0+bzr6595 GIT=v1.7.10.4 SVN=1.7.5 PYYAML=3.10
 # bzr 2.1.1 only builds with python 2.6
 matrix:
   exclude:


### PR DESCRIPTION
There have been updates to the ubuntu apt repository causing 404s for installs without the updates.

This should fix the travis errors seen in #92 
