### PR TITLE
Two test fixes

### DIFF
--- a/test/test_git.py
+++ b/test/test_git.py
@@ -43,6 +43,7 @@ import types
 import threading
 import time
 
+from distutils.version import LooseVersion
 from vcstools import GitClient
 from vcstools.vcs_base import VcsError
 
@@ -236,9 +237,13 @@ class GitClientTest(GitClientTestSetups):
         self.assertEqual(client.get_branch(), "master")
         self.assertEqual(client.get_branch_parent(), "master")
         po = subprocess.Popen("git log --pretty=format:%H", shell=True, cwd=self.local_path, stdout=subprocess.PIPE)
-        log = po.stdout.read().decode('UTF-8').splitlines()
-        # shallow only contains last 2 commits
-        self.assertEqual(2, len(log), log)
+        log = po.stdout.read().decode('UTF-8').strip().splitlines()
+        if LooseVersion(client.gitversion) >= LooseVersion('1.8.2'):
+            # shallow only contains last commit
+            self.assertEqual(1, len(log), log)
+        else:
+            # shallow only contains last 2 commits
+            self.assertEqual(2, len(log), log)
 
     def test_checkout_specific_version_and_update(self):
         url = self.remote_path

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -774,7 +774,9 @@ class GitTimeoutTest(unittest.TestCase):
 
     class MuteHandler(BaseRequestHandler):
         def handle(self):
-            self.request.recv(1024)
+            data = True
+            while data:
+                data = self.request.recv(1024)
 
     @classmethod
     def setUpClass(self):


### PR DESCRIPTION
Two test failures:

1) The behavior of --depth changed in 1.8.2. Previously, when --depth=n was specified, the most recent n + 1 commits were present in the clone. In 1.8.2 and newer, the most recent n commits are.

See https://raw.githubusercontent.com/gitster/git/master/Documentation/RelNotes/1.8.2.txt

2) If the git timeout test is run on a machine which can run many threads, the TCP server finishes the call to `handle` and resets the connection before the timeout has occurred, and the test fails.

Thanks,

--scott