### PR TITLE
more commands to use for divergence information in wstool/rosws info

### DIFF
--- a/src/vcstools/bzr.py
+++ b/src/vcstools/bzr.py
@@ -208,6 +208,15 @@ class BzrClient(VcsClientBase):
                                                  us_env=True)
                 return output.strip()
 
+    def get_current_version_label(self):
+        # url contains branch information
+        return None
+
+    def get_remote_version(self, fetch=False):
+        # Not sure how to get any useful information from bzr about this,
+        # since bzr has no globally unique IDs
+        return None
+
     def get_diff(self, basepath=None):
         response = None
         if basepath is None:

--- a/src/vcstools/common.py
+++ b/src/vcstools/common.py
@@ -261,7 +261,7 @@ def _read_shell_output(proc, no_filter, verbose, show_stdout, output_queue):
 
 def run_shell_command(cmd, cwd=None, shell=False, us_env=True,
                       show_stdout=False, verbose=False, timeout=None,
-                      no_warn=False, no_filter=False):
+                      no_filter=False):
     """
     executes a command and hides the stdout output, loggs stderr
     output when command result is not zero. Make sure to sanitize
@@ -271,8 +271,7 @@ def run_shell_command(cmd, cwd=None, shell=False, us_env=True,
     :param shell: Whether to use os shell.
     :param us_env: changes env var LANG before running command, can influence program output
     :param show_stdout: show some of the output (except for discarded lines in _discard_line()), ignored if no_filter
-    :param no_warn: hides warnings
-    :param verbose: show all output, overrides no_warn, ignored if no_filter
+    :param verbose: show all output, ignored if no_filter
     :param timeout: time allocated to the subprocess
     :param no_filter: does not wrap stdout, so invoked command prints everything outside our knowledge
     this is DANGEROUS, as vulnerable to shell injection.

--- a/src/vcstools/hg.py
+++ b/src/vcstools/hg.py
@@ -262,10 +262,10 @@ class HgClient(VcsClientBase):
                                          '{autor|email}', '{date|isodate}',
                                          '{desc}']) + '\x1e'
 
-            command = "hg log %s --template '%s' %s" % (sanitized(relpath),
-                                                        HG_LOG_FORMAT,
-                                                        limit_cmd)
-
+            command = "hg log %s -b %s --template '%s' %s" % (sanitized(relpath),
+                                                              self.get_branch(),
+                                                              HG_LOG_FORMAT,
+                                                              limit_cmd)
             return_code, response_str, stderr = run_shell_command(command, shell=True, cwd=self._path)
 
             if return_code == 0:

--- a/src/vcstools/hg.py
+++ b/src/vcstools/hg.py
@@ -237,6 +237,34 @@ class HgClient(VcsClientBase):
             # changes, inconsistent to hg log
             return output.strip().rstrip('+')
 
+    def get_current_version_label(self):
+        """
+        :param spec: (optional) spec can be what 'svn info --help'
+          allows, meaning a revnumber, {date}, HEAD, BASE, PREV, or
+          COMMITTED.
+        :returns: current revision number of the repository. Or if spec
+          provided, the number of a revision specified by some
+          token.
+        """
+        return self.get_branch()
+
+    def get_branch(self):
+        if self.path_exists():
+            command = "hg branch --repository %s" % self.get_path()
+            _, output, _ = run_shell_command(command, shell=True)
+            if output is not None:
+                return output.strip()
+        return None
+
+    def get_remote_version(self, fetch=False):
+        if fetch:
+            self._do_pull(filter=True)
+        # use local information only
+        result = self.get_log(limit=1)
+        if (len(result) == 1 and 'id' in result[0]):
+            return result[0]['id']
+        return None
+
     def get_diff(self, basepath=None):
         response = None
         if basepath is None:
@@ -318,11 +346,11 @@ class HgClient(VcsClientBase):
             os.remove(basepath + '.tar')
         return True
 
-    def _do_pull(self):
+    def _do_pull(self, filter=False):
         value, _, _ = run_shell_command("hg pull",
                                         cwd=self._path,
                                         shell=True,
-                                        no_filter=True)
+                                        no_filter=not filter)
         return value == 0
 
 # backwards compat

--- a/src/vcstools/svn.py
+++ b/src/vcstools/svn.py
@@ -183,11 +183,11 @@ class SvnClient(VcsClientBase):
         _, output, _ = run_shell_command(command, shell=True, us_env=True)
         if output is not None:
             matches = \
-                [l for l in output.splitlines() if l.startswith('Revision: ')]
+                [l for l in output.splitlines() if l.startswith('Last Changed Rev: ')]
             if len(matches) == 1:
                 split_str = matches[0].split()
-                if len(split_str) == 2:
-                    return '-r' + split_str[1]
+                if len(split_str) == 4:
+                    return '-r' + split_str[3]
         return None
 
     def get_diff(self, basepath=None):

--- a/src/vcstools/tar.py
+++ b/src/vcstools/tar.py
@@ -169,6 +169,14 @@ class TarClient(VcsClientBase):
                     return metadata['version']
         return None
 
+    def get_current_version_label(self):
+        # exploded tar has no local version
+        return None
+
+    def get_remote_version(self, fetch=False):
+        # exploded tar has no remote version (not a required feature)
+        return None
+
     def get_diff(self, basepath=None):
         return ''
 

--- a/src/vcstools/vcs_abstraction.py
+++ b/src/vcstools/vcs_abstraction.py
@@ -101,6 +101,12 @@ class VcsClient(object):
     def get_version(self, spec=None):
         return self.vcs.get_version(spec)
 
+    def get_current_version_label(self):
+        return self.vcs.get_current_version_label()
+
+    def get_remote_version(self, fetch=False):
+        return self.vcs.get_remote_version(fetch)
+
     def checkout(self, url, version='', verbose=False, shallow=False):
         return self.vcs.checkout(url,
                                  version,

--- a/src/vcstools/vcs_base.py
+++ b/src/vcstools/vcs_base.py
@@ -130,6 +130,33 @@ class VcsClientBase(object):
         raise NotImplementedError("Base class get_version method must be overridden for client type %s " %
                                   self._vcs_type_name)
 
+    def get_current_version_label(self):
+        """
+        Find an description for the current local version.
+        Token spec might be a branchname,
+        version-id, SHA-ID, ... depending on the VCS implementation.
+
+        :type spec: str
+        :returns: short description of local version (e.g. branchname, tagename).
+        :rtype: str
+        """
+        raise NotImplementedError("Base class get_current_version method must be overridden for client type %s " %
+                                  self._vcs_type_name)
+
+    def get_remote_version(self, fatch=False):
+        """
+        Find an identifier for the current revision on remote.
+        Token spec might be a tagname,
+        version-id, SHA-ID, ... depending on the VCS implementation.
+
+        :param fetch: if False, only local information may be used
+        :type spec: str
+        :returns: current revision number of the remote repository.
+        :rtype: str
+        """
+        raise NotImplementedError("Base class get_remote_version method must be overridden for client type %s " %
+                                  self._vcs_type_name)
+
     def checkout(self, url, version=None, verbose=False, shallow=False, timeout=None):
         """
         Attempts to create a local repository given a remote


### PR DESCRIPTION
Not to be merged yet, this PR is to allow travis to check for compatibility and to summarize what still needs to be done

TODO:
- [x] git implementation
- [x] git tests
- [x] svn implementation
- [x] svn tests
- [x] hg implementation
- [x] hg tests
- [x] bzr implementation
- [x] bzr tests
- [x] tar implementation + tests (noop functions)
- [x] decide about git fetch (use --fetch)
- [x] decide about hg named branches vs bookmarks (decided: named branches)

- [x] implement ..fetch in vcstools and wstool
- [x] validate works with wstool

- [x] code review (Kentaro), check for leftover print(), TODO, typos, code style
- [x] code review (@wjwwood)
