### PR TITLE
Handle new test failures with subversion 1.9

### DIFF
--- a/test/test_svn.py
+++ b/test/test_svn.py
@@ -371,6 +371,8 @@ class SvnDiffStatClientTest(SvnClientTestSetups):
                     # new svn versions use different labels for added
                     # files (working copy) vs (revision x)
                     fixedline = re.sub('\(revision [0-9]+\)', '(working copy)', line)
+                    # svn 1.9 added (nonexistent)
+                    fixedline = re.sub('\(nonexistent\)', '(working copy)', fixedline)
                     newblock.append(fixedline)
             return "\n".join(newblock)
 


### PR DESCRIPTION
Added an additional cleanup step to handle a new "nonexistent" state added in subversion 1.9.  This fixes two failing unit tests I noticed when updating fedora packages for newer versions of fedora that include subversion 1.9.0.

Failed rpm build/test run with subversion 1.9.0: https://kojipkgs.fedoraproject.org//work/tasks/4444/11074444/build.log

Successful rpm build/test run with this PR applied: https://kojipkgs.fedoraproject.org//work/tasks/4726/11074726/build.log