### PR TITLE
Added Ubuntu Wily (15.10) and Xenial (16.04)

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [DEFAULT]
 Depends: subversion, mercurial, git-core, bzr, python-yaml, python-dateutil
 Depends3: subversion, mercurial, git-core, bzr, python3-yaml
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wheezy jessie
+Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial wheezy jessie
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Added Ubuntu Wily (15.10) and Xenial (16.04) to the list of supported platforms.