### PR TITLE
Implement get_affected_files method for getting the files affected by a revision.

### DIFF
--- a/src/vcstools/bzr.py
+++ b/src/vcstools/bzr.py
@@ -228,6 +228,18 @@ class BzrClient(VcsClientBase):
             _, response, _ = run_shell_command(command, shell=True, cwd=basepath)
         return response
 
+    def get_affected_files(self, revision):
+        cmd = "bzr status -c {0} -S -V".format(
+            revision)
+
+        code, output, _ = run_shell_command(cmd, shell=True, cwd=self._path)
+
+        affected = []
+        if code == 0:
+            for filename in output.splitlines():
+                affected.append(filename.split(" ")[2])
+        return affected
+
     def get_log(self, relpath=None, limit=None):
         response = []
 

--- a/src/vcstools/git.py
+++ b/src/vcstools/git.py
@@ -455,6 +455,17 @@ class GitClient(VcsClientBase):
                 response += _git_diff_path_submodule_change(output, rel_path)
         return response
 
+    def get_affected_files(self, revision):
+        cmd = "git show {0} --pretty='format:' --name-only".format(
+            revision)
+        code, output, _ = run_shell_command(cmd, shell=True, cwd=self._path)
+        affected = []
+        if code == 0:
+            for filename in output.splitlines():
+                if filename not in ('', None, ):
+                    affected.append(filename)
+        return affected
+
     def get_log(self, relpath=None, limit=None):
         response = []
 

--- a/src/vcstools/hg.py
+++ b/src/vcstools/hg.py
@@ -276,6 +276,14 @@ class HgClient(VcsClientBase):
             response = _hg_diff_path_change(response, rel_path)
         return response
 
+    def get_affected_files(self, revision):
+        cmd = "hg log -r %s --template '{files}'" % revision
+        code, output, _ = run_shell_command(cmd, shell=True, cwd=self._path)
+        affected = []
+        if code == 0:
+            affected = output.split(" ")
+        return affected
+
     def get_log(self, relpath=None, limit=None):
         response = []
 

--- a/src/vcstools/svn.py
+++ b/src/vcstools/svn.py
@@ -291,6 +291,17 @@ class SvnClient(VcsClientBase):
                                                cwd=basepath)
         return response
 
+    def get_affected_files(self, revision):
+        cmd = "svn diff --summarize -c {0}".format(
+            revision)
+
+        code, output, _ = run_shell_command(cmd, shell=True, cwd=self._path)
+        affected = []
+        if code == 0:
+            for filename in output.splitlines():
+                affected.append(filename.split(" ")[7])
+        return affected
+
     def get_log(self, relpath=None, limit=None):
         response = []
 

--- a/src/vcstools/vcs_base.py
+++ b/src/vcstools/vcs_base.py
@@ -254,6 +254,15 @@ class VcsClientBase(object):
         raise NotImplementedError("Base class get_status method must be overridden for client type %s " %
                                   self._vcs_type_name)
 
+    def get_affected_files(self, revision):
+        """
+        Get the files that were affected by a specific revision
+        :param revision: SHA or revision number.
+        :returns: A list of strings with the files affected by a specific commit
+        """
+        raise NotImplemented(
+            "Base class get_affected_files method must be overriden")
+
     def get_log(self, relpath=None, limit=None):
         """
         Calls scm log command.

--- a/test/test_bzr.py
+++ b/test/test_bzr.py
@@ -260,6 +260,23 @@ class BzrClientLogTest(BzrClientTestSetups):
         self.assertEquals('initial', log[0]['message'])
 
 
+class BzrClientAffectedFilesTest(BzrClientTestSetups):
+
+    @classmethod
+    def setUpClass(self):
+        BzrClientTestSetups.setUpClass()
+        client = BzrClient(self.local_path)
+        client.checkout(self.remote_path)
+
+    def test_get_log_defaults(self):
+        client = BzrClient(self.local_path)
+        client.checkout(self.remote_path)
+        log = client.get_log(limit=1)[0]
+        affected = client.get_affected_files(log['id'])
+        self.assertEqual(sorted(['deleted-fs.txt', 'deleted.txt']),
+                         sorted(affected))
+
+
 class BzrDiffStatClientTest(BzrClientTestSetups):
 
     @classmethod

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -595,6 +595,28 @@ class GitClientLogTest(GitClientTestSetups):
             self.assertEquals(1, len(log))
 
 
+class GitClientAffectedFiles(GitClientTestSetups):
+
+    def setUp(self):
+        client = GitClient(self.local_path)
+        client.checkout(self.remote_path)
+        # Create some local untracking branch
+
+        subprocess.check_call("git checkout test_tag -b localbranch", shell=True, cwd=self.local_path)
+        subprocess.check_call("touch local_file", shell=True, cwd=self.local_path)
+        subprocess.check_call("git add local_file", shell=True, cwd=self.local_path)
+        subprocess.check_call("git commit -m \"local_file\"", shell=True, cwd=self.local_path)
+
+    def test_get_affected_files(self):
+        client = GitClient(self.local_path)
+        affected = client.get_affected_files(client.get_log()[0]['id'])
+
+        self.assertEqual(sorted(['local_file']),
+                         sorted(affected))
+
+        self.assertEquals(['local_file'], affected)
+
+
 class GitClientDanglingCommitsTest(GitClientTestSetups):
 
     def setUp(self):

--- a/test/test_hg.py
+++ b/test/test_hg.py
@@ -276,6 +276,25 @@ class HGClientLogTest(HGClientTestSetups):
         self.assertEquals('initial', log[0]['message'])
 
 
+class HGAffectedFilesTest(HGClientTestSetups):
+
+    @classmethod
+    def setUpClass(self):
+        HGClientTestSetups.setUpClass()
+        client = HgClient(self.local_path)
+        client.checkout(self.local_url)
+
+    def test_get_log_defaults(self):
+        client = HgClient(self.local_path)
+        client.checkout(self.local_url)
+        log = client.get_log(limit=1)[0]
+        affected = client.get_affected_files(log['id'])
+
+        self.assertEqual(sorted(['deleted-fs.txt', 'deleted.txt']),
+                         sorted(affected))
+
+
+
 class HGDiffStatClientTest(HGClientTestSetups):
 
     @classmethod

--- a/test/test_svn.py
+++ b/test/test_svn.py
@@ -322,6 +322,24 @@ class SvnClientLogTest(SvnClientTestSetups):
         self.assertEquals('initial', log[0]['message'])
 
 
+class SVNClientAffectedFiles(SvnClientTestSetups):
+
+    @classmethod
+    def setUpClass(self):
+        SvnClientTestSetups.setUpClass()
+        client = SvnClient(self.local_path)
+        client.checkout(self.local_url)
+
+    def test_get_affected_files(self):
+        client = SvnClient(self.local_path)
+        client.checkout(self.local_url)
+        log = client.get_log(limit=1)[0]
+        affected = client.get_affected_files(log['id'])
+
+        self.assertEqual(sorted(['deleted-fs.txt', 'deleted.txt']),
+                         sorted(affected))
+
+
 class SvnDiffStatClientTest(SvnClientTestSetups):
 
     @classmethod


### PR DESCRIPTION
This commit implements the get_affected_files on all the backends, in
order to get the files affected (deleted/modified/added) by a given revision/version.

- Also added tests for validating the change.

Signed-off-by: Jorge Niedbalski <jnr@metaklass.org>