### PR TITLE
More friendly instruction for git remote issue.

### DIFF
--- a/src/vcstools/git.py
+++ b/src/vcstools/git.py
@@ -305,7 +305,9 @@ class GitClient(VcsClientBase):
                         # if remote is not origin, must not fast-forward (because based on origin)
                         logger = logging.getLogger('vcstools')
                         logger.warn("vcstools only handles branches tracking default remote,"
-                                    " branch '%s' tracks remote '%s'.\nRepository path is '%s'."
+                                    " branch '%s' tracks remote '%s'. Make sure to set the right"
+                                    " remote if the remote is not what you expect.\nRepository"
+                                    " path is '%s'."
                                     % (current_branch, remote, self._path))
                         branch_parent = None
                 # already on correct branch, fast-forward if there is a parent

--- a/src/vcstools/git.py
+++ b/src/vcstools/git.py
@@ -304,11 +304,7 @@ class GitClient(VcsClientBase):
                     if remote != default_remote:
                         # if remote is not origin, must not fast-forward (because based on origin)
                         logger = logging.getLogger('vcstools')
-                        logger.warn("vcstools only handles branches tracking default remote,"
-                                    " branch '%s' tracks remote '%s'. Make sure to set the right"
-                                    " remote if the remote is not what you expect.\nRepository"
-                                    " path is '%s'."
-                                    % (current_branch, remote, self._path))
+                        logger.warn(self._msg_invalid_remote(current_branch, remote, self._path))
                         branch_parent = None
                 # already on correct branch, fast-forward if there is a parent
                 if branch_parent:
@@ -354,8 +350,7 @@ class GitClient(VcsClientBase):
                 (new_branch_parent, remote) = self._get_branch_parent(current_branch=refname)
                 if remote != default_remote:
                     # if remote is not origin, must not fast-forward (because based on origin)
-                    sys.stderr.write("vcstools only handles branches tracking default remote," +
-                                     " branch '%s' tracks remote '%s'\n" % (current_branch, remote))
+                    sys.stderr.write(self._msg_invalid_remote(current_branch, remote, self._path))
                     new_branch_parent = None
                 if new_branch_parent is not None:
                     if fast_foward:
@@ -364,6 +359,15 @@ class GitClient(VcsClientBase):
                                                      verbose=verbose):
                             return False
         return (not update_submodules) or self._update_submodules(verbose=verbose, timeout=timeout)
+
+    def _msg_invalid_remote(self, current_branch, remote, path_repo):
+        """
+        Returns warning msg when the remote is invalid. 
+        See https://github.com/vcstools/vcstools/pull/137
+        """
+        return """vcstools can only handle branches tracking remote named
+origin, but branch '%s' tracks remote '%s'.\nPlease reconfigure remote or change branch.
+Repository path is '%s'.""" % (current_branch, remote, path_repo)
 
     def get_current_version_label(self):
         """


### PR DESCRIPTION
AFAIUC, the following warning ([link to github](https://github.com/vcstools/vcstools/blob/8aed3826e8eef4e2c4e3e829cb08d4056fcf1d6e/src/vcstools/git.py#L307)) gets printed when `remote` is not what's expected, which I had to spend some time to figure out.

```
    logger.warn("vcstools only handles branches tracking default remote,"
        " branch '%s' tracks remote '%s'.\nRepository path is '%s'."
        % (current_branch, remote, self._path))
```

Nicer warning message helps, although I'm not sure if the change in this PR helps. I'd be fine detailing set of example commands, but that could vary depending on the situation so might not be easy. Add a link to useful webpage is another option but haven't figured out the best one.