### PR TITLE
[Windows] vcstools initial bring up for Windows (git)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,60 @@
+# Continuous integration procedure for AppVeyor
+# Based on https://github.com/rmcgibbo/python-appveyor-conda-example
+
+environment:
+
+  matrix:
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
+
+install:
+  - set PATH=C:\Program Files (x86)\GnuWin32\bin\;%PYTHON%\Scripts;%PYTHON%;%PATH%
+  - python --version
+  - python -m site
+  - python -m pip install -U pip setuptools wheel nose mock
+  - python setup.py install
+
+  # install bzip2
+  - ps: Start-FileDownload 'http://liquidtelecom.dl.sourceforge.net/project/gnuwin32/bzip2/1.0.5/bzip2-1.0.5-setup.exe'
+  - bzip2-1.0.5-setup.exe /VERYSILENT
+  - bzip2 --help
+
+  # install tar
+  - ps: Start-FileDownload 'http://liquidtelecom.dl.sourceforge.net/project/gnuwin32/libarchive/2.4.12-1/libarchive-2.4.12-1-setup.exe'
+  - libarchive-2.4.12-1-setup.exe /VERYSILENT
+  - mklink "C:\Program Files (x86)\GnuWin32\bin\tar.exe" "C:\Program Files (x86)\GnuWin32\bin\bsdtar.exe"
+  - where tar
+
+  # install bzr (python 2.7 is required)
+  - c:\python27\python -m pip install -U bzr --global-option build_ext --global-option --allow-python-fallback
+
+  # check all version control system versions
+  - hg --version
+  - bzr --version
+  - git --version
+  - svn --version
+
+  # change default encoding to utf-8 (for python 2.* only)
+  - ps: |
+      if ($(iex "python -c 'import platform; print(platform.python_version())'") -like "2*")
+      {
+        $user_site = iex 'python -m site --user-site'
+        mkdir $user_site
+        "import sys; sys.setdefaultencoding('utf-8');" | Out-File -Encoding UTF8 $(Join-Path $user_site "sitecustomize.py")
+        python -c "import sys; print(sys.getdefaultencoding())"
+      }
+  
+  # change the console encoding to utf-8
+  - chcp 65001
+
+build: none
+
+test_script:
+  # Nosetests take care of unit tests
+  - python -m nose --with-xunit
+
+on_finish:
+  - ps: |
+      $wc = New-Object 'System.Net.WebClient'
+      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\nosetests.xml))

--- a/src/vcstools/bzr.py
+++ b/src/vcstools/bzr.py
@@ -106,6 +106,8 @@ class BzrClient(VcsClientBase):
                     result = os.path.abspath(os.path.join(os.getcwd(), ppath))
                 else:
                     result = ppath
+        if result is not None:
+            result = os.path.normcase(result)
         return result
 
     def url_matches(self, url, url_or_shortcut):
@@ -190,8 +192,7 @@ class BzrClient(VcsClientBase):
         """
         if self.detect_presence():
             if spec is not None:
-                command = ['bzr log -r %s .' % sanitized(spec)]
-                _, output, _ = run_shell_command(command,
+                _, output, _ = run_shell_command('bzr log -r %s .' % sanitized(spec),
                                                  shell=True,
                                                  cwd=self._path,
                                                  us_env=True)

--- a/src/vcstools/git_archive_all.py
+++ b/src/vcstools/git_archive_all.py
@@ -31,7 +31,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import logging
-from os import extsep, path, readlink, curdir
+from os import extsep, path, curdir
 from subprocess import CalledProcessError, Popen, PIPE
 import sys
 import tarfile
@@ -40,6 +40,13 @@ import re
 
 __version__ = "1.16.4"
 
+def os_readlink(file_path):
+    if hasattr(os, 'readlink'):
+        from os import readlink
+        return readlink(file_path)
+    else:
+        from os.path import realpath
+        return realpath(file_path)
 
 class GitArchiver(object):
     """
@@ -132,7 +139,7 @@ class GitArchiver(object):
                         i = ZipInfo(arcname)
                         i.create_system = 3
                         i.external_attr = 0xA1ED0000
-                        archive.writestr(i, readlink(file_path))
+                        archive.writestr(i, os_readlink(file_path))
             elif output_format in ['tar', 'bz2', 'gz', 'xz', 'tgz', 'txz']:
                 if output_format == 'tar':
                     t_mode = 'w'

--- a/src/vcstools/hg.py
+++ b/src/vcstools/hg.py
@@ -46,7 +46,7 @@ import gzip
 import dateutil.parser  # For parsing date strings
 
 from vcstools.vcs_base import VcsClientBase, VcsError
-from vcstools.common import sanitized, normalized_rel_path, run_shell_command
+from vcstools.common import sanitized, normalized_rel_path, run_shell_command, rmtree
 
 
 def _get_hg_version():
@@ -78,7 +78,7 @@ def _hg_diff_path_change(diff, path):
     # the actual diff
     state = INIT
 
-    s_list = [line for line in diff.split(os.linesep)]
+    s_list = diff.splitlines()
     lines = []
     for line in s_list:
         if line.startswith("diff"):
@@ -277,7 +277,7 @@ class HgClient(VcsClientBase):
         return response
 
     def get_affected_files(self, revision):
-        cmd = "hg log -r %s --template '{files}'" % revision
+        cmd = "hg log -r %s --template \"{files}\"" % revision
         code, output, _ = run_shell_command(cmd, shell=True, cwd=self._path)
         affected = []
         if code == 0:
@@ -298,7 +298,7 @@ class HgClient(VcsClientBase):
                                          '{autor|email}', '{date|isodate}',
                                          '{desc}']) + '\x1e'
 
-            command = "hg log %s -b %s --template '%s' %s" % (sanitized(relpath),
+            command = "hg log %s -b %s --template \"%s\" %s" % (sanitized(relpath),
                                                               self.get_branch(),
                                                               HG_LOG_FORMAT,
                                                               limit_cmd)

--- a/src/vcstools/svn.py
+++ b/src/vcstools/svn.py
@@ -50,7 +50,7 @@ import xml.dom.minidom  # For parsing logfiles
 
 from vcstools.vcs_base import VcsClientBase, VcsError
 from vcstools.common import sanitized, normalized_rel_path, \
-    run_shell_command, ensure_dir_notexists
+    run_shell_command, ensure_dir_notexists, rmtree
 
 
 def canonical_svn_url_split(url):
@@ -373,7 +373,6 @@ class SvnClient(VcsClientBase):
                 targzip_file.close()
         finally:
             # clean up
-            from shutil import rmtree
             rmtree(basepath)
         return True
 

--- a/src/vcstools/tar.py
+++ b/src/vcstools/tar.py
@@ -42,12 +42,12 @@ tarfile with a folder inside for each version.
 from __future__ import absolute_import, print_function, unicode_literals
 import os
 import tempfile
-import shutil
 import tarfile
+import shutil
 import sys
 import yaml
 from vcstools.vcs_base import VcsClientBase, VcsError
-from vcstools.common import urlretrieve_netrc, ensure_dir_notexists
+from vcstools.common import urlretrieve_netrc, ensure_dir_notexists, rmtree
 
 
 __pychecker__ = 'unusednames=spec'
@@ -118,10 +118,11 @@ class TarClient(VcsClientBase):
                 subdirs = []
                 members = []
                 for m in temp_tarfile.getmembers():
-                    if m.name.startswith(version + '/'):
+                    norm_mname = os.path.normpath(m.name)
+                    if norm_mname.startswith(version + os.sep):
                         members.append(m)
-                    if m.name.split('/')[0] not in subdirs:
-                        subdirs.append(m.name.split('/')[0])
+                    if norm_mname.split(os.sep)[0] not in subdirs:
+                        subdirs.append(norm_mname.split(os.sep)[0])
                 if not members:
                     raise VcsError("%s is not a subdirectory with contents in members %s" % (version, subdirs))
                 subdir = os.path.join(tempdir, version)
@@ -144,7 +145,7 @@ class TarClient(VcsClientBase):
             self.logger.error("Tarball download unpack failed: %s" % str(exc))
         finally:
             if tempdir is not None and os.path.exists(tempdir):
-                shutil.rmtree(tempdir)
+                rmtree(tempdir)
         return result
 
     def update(self, version='', verbose=False, timeout=None):

--- a/test/test_hg.py
+++ b/test/test_hg.py
@@ -38,12 +38,13 @@ import io
 import unittest
 import subprocess
 import tempfile
-import shutil
 
+from vcstools.common import rmtree
 from vcstools.hg import HgClient
+from .util import _touch
 
 
-os.environ['EMAIL'] = 'Your Name <name@example.com>'
+os.environ[str('EMAIL')] = str('Your Name <name@example.com>')
 
 
 class HGClientTestSetups(unittest.TestCase):
@@ -57,62 +58,65 @@ class HGClientTestSetups(unittest.TestCase):
         os.makedirs(self.remote_path)
 
         # create a "remote" repo
+        subprocess.check_call("hg init", shell=True, cwd=self.remote_path)
+        _touch(os.path.join(self.remote_path, "fixed.txt"))
         for cmd in [
-                "hg init",
-                "touch fixed.txt",
                 "hg add fixed.txt",
                 "hg commit -m initial"]:
             subprocess.check_call(cmd, shell=True, cwd=self.remote_path)
 
-        po = subprocess.Popen("hg log --template '{node|short}' -l1", shell=True, cwd=self.remote_path, stdout=subprocess.PIPE)
+        po = subprocess.Popen("hg log --template \"{node|short}\" -l1", shell=True, cwd=self.remote_path, stdout=subprocess.PIPE)
         self.local_version_init = po.stdout.read().decode('UTF-8').rstrip("'").lstrip("'")
         # in hg, tagging creates an own changeset, so we need to fetch version before tagging
         subprocess.check_call("hg tag test_tag", shell=True, cwd=self.remote_path)
 
+        _touch(os.path.join(self.remote_path, "modified.txt"))
+        _touch(os.path.join(self.remote_path, "modified-fs.txt"))
+
         # files to be modified in "local" repo
         for cmd in [
-                "touch modified.txt",
-                "touch modified-fs.txt",
                 "hg add modified.txt modified-fs.txt",
                 "hg commit -m initial"]:
             subprocess.check_call(cmd, shell=True, cwd=self.remote_path)
 
-        po = subprocess.Popen("hg log --template '{node|short}' -l1", shell=True, cwd=self.remote_path, stdout=subprocess.PIPE)
+        po = subprocess.Popen("hg log --template \"{node|short}\" -l1", shell=True, cwd=self.remote_path, stdout=subprocess.PIPE)
         self.local_version_second = po.stdout.read().decode('UTF-8').rstrip("'").lstrip("'")
 
+        _touch(os.path.join(self.remote_path, "deleted.txt"))
+        _touch(os.path.join(self.remote_path, "deleted-fs.txt"))
+
         for cmd in [
-                "touch deleted.txt",
-                "touch deleted-fs.txt",
                 "hg add deleted.txt deleted-fs.txt",
                 "hg commit -m modified"]:
             subprocess.check_call(cmd, shell=True, cwd=self.remote_path)
 
-        po = subprocess.Popen("hg log --template '{node|short}' -l1", shell=True, cwd=self.remote_path, stdout=subprocess.PIPE)
+        po = subprocess.Popen("hg log --template \"{node|short}\" -l1", shell=True, cwd=self.remote_path, stdout=subprocess.PIPE)
         self.local_version = po.stdout.read().decode('UTF-8').rstrip("'").lstrip("'")
 
         self.local_path = os.path.join(self.root_directory, "local")
         self.local_url = self.remote_path
 
         # create a hg branch
+        subprocess.check_call("hg branch test_branch", shell=True, cwd=self.remote_path)
+        _touch(os.path.join(self.remote_path, "test.txt"))
+
         for cmd in [
-                "hg branch test_branch",
-                "touch test.txt",
                 "hg add test.txt",
                 "hg commit -m test"]:
             subprocess.check_call(cmd, shell=True, cwd=self.remote_path)
 
-        po = subprocess.Popen("hg log --template '{node|short}' -l1", shell=True, cwd=self.remote_path, stdout=subprocess.PIPE)
+        po = subprocess.Popen("hg log --template \"{node|short}\" -l1", shell=True, cwd=self.remote_path, stdout=subprocess.PIPE)
         self.branch_version = po.stdout.read().decode('UTF-8').rstrip("'").lstrip("'")
 
 
     @classmethod
     def tearDownClass(self):
         for d in self.directories:
-            shutil.rmtree(self.directories[d])
+            rmtree(self.directories[d])
 
     def tearDown(self):
         if os.path.exists(self.local_path):
-            shutil.rmtree(self.local_path)
+            rmtree(self.local_path)
 
 
 class HGClientTest(HGClientTestSetups):
@@ -307,7 +311,7 @@ class HGDiffStatClientTest(HGClientTestSetups):
         client = HgClient(self.local_path)
         client.checkout(url)
         # after setting up "local" repo, change files and make some changes
-        subprocess.check_call("rm deleted-fs.txt", shell=True, cwd=self.local_path)
+        os.remove(os.path.join(self.local_path, "deleted-fs.txt"))
         subprocess.check_call("hg rm deleted.txt", shell=True, cwd=self.local_path)
         f = io.open(os.path.join(self.local_path, "modified.txt"), 'a')
         f.write('0123456789abcdef')
@@ -331,7 +335,28 @@ class HGDiffStatClientTest(HGClientTestSetups):
         client = HgClient(self.local_path)
         self.assertTrue(client.path_exists())
         self.assertTrue(client.detect_presence())
-        self.assertEquals('diff --git ./added.txt ./added.txt\nnew file mode 100644\n--- /dev/null\n+++ ./added.txt\n@@ -0,0 +1,1 @@\n+0123456789abcdef\n\\ No newline at end of file\ndiff --git ./deleted.txt ./deleted.txt\ndeleted file mode 100644\ndiff --git ./modified-fs.txt ./modified-fs.txt\n--- ./modified-fs.txt\n+++ ./modified-fs.txt\n@@ -0,0 +1,1 @@\n+0123456789abcdef\n\\ No newline at end of file\ndiff --git ./modified.txt ./modified.txt\n--- ./modified.txt\n+++ ./modified.txt\n@@ -0,0 +1,1 @@\n+0123456789abcdef\n\\ No newline at end of file', client.get_diff())
+        self.assertEquals('''\
+diff --git ./added.txt ./added.txt
+new file mode 100644
+--- /dev/null
++++ ./added.txt
+@@ -0,0 +1,1 @@
++0123456789abcdef
+\\ No newline at end of file
+diff --git ./deleted.txt ./deleted.txt
+deleted file mode 100644
+diff --git ./modified-fs.txt ./modified-fs.txt
+--- ./modified-fs.txt
++++ ./modified-fs.txt
+@@ -0,0 +1,1 @@
++0123456789abcdef
+\\ No newline at end of file
+diff --git ./modified.txt ./modified.txt
+--- ./modified.txt
++++ ./modified.txt
+@@ -0,0 +1,1 @@
++0123456789abcdef
+\\ No newline at end of file''', client.get_diff())
 
     def test_diff_relpath(self):
 
@@ -339,7 +364,28 @@ class HGDiffStatClientTest(HGClientTestSetups):
         self.assertTrue(client.path_exists())
         self.assertTrue(client.detect_presence())
 
-        self.assertEquals('diff --git local/added.txt local/added.txt\nnew file mode 100644\n--- /dev/null\n+++ local/added.txt\n@@ -0,0 +1,1 @@\n+0123456789abcdef\n\\ No newline at end of file\ndiff --git local/deleted.txt local/deleted.txt\ndeleted file mode 100644\ndiff --git local/modified-fs.txt local/modified-fs.txt\n--- local/modified-fs.txt\n+++ local/modified-fs.txt\n@@ -0,0 +1,1 @@\n+0123456789abcdef\n\\ No newline at end of file\ndiff --git local/modified.txt local/modified.txt\n--- local/modified.txt\n+++ local/modified.txt\n@@ -0,0 +1,1 @@\n+0123456789abcdef\n\\ No newline at end of file', client.get_diff(basepath=os.path.dirname(self.local_path)))
+        self.assertEquals('''\
+diff --git local/added.txt local/added.txt
+new file mode 100644
+--- /dev/null
++++ local/added.txt
+@@ -0,0 +1,1 @@
++0123456789abcdef
+\\ No newline at end of file
+diff --git local/deleted.txt local/deleted.txt
+deleted file mode 100644
+diff --git local/modified-fs.txt local/modified-fs.txt
+--- local/modified-fs.txt
++++ local/modified-fs.txt
+@@ -0,0 +1,1 @@
++0123456789abcdef
+\\ No newline at end of file
+diff --git local/modified.txt local/modified.txt
+--- local/modified.txt
++++ local/modified.txt
+@@ -0,0 +1,1 @@
++0123456789abcdef
+\\ No newline at end of file''', client.get_diff(basepath=os.path.dirname(self.local_path)))
 
     def test_get_version_modified(self):
         client = HgClient(self.local_path)
@@ -349,19 +395,38 @@ class HGDiffStatClientTest(HGClientTestSetups):
         client = HgClient(self.local_path)
         self.assertTrue(client.path_exists())
         self.assertTrue(client.detect_presence())
-        self.assertEquals('M modified-fs.txt\nM modified.txt\nA added.txt\nR deleted.txt\n! deleted-fs.txt\n', client.get_status())
+        self.assertEquals('''\
+M modified-fs.txt
+M modified.txt
+A added.txt
+R deleted.txt
+! deleted-fs.txt
+''', client.get_status())
 
     def test_status_relpath(self):
         client = HgClient(self.local_path)
         self.assertTrue(client.path_exists())
         self.assertTrue(client.detect_presence())
-        self.assertEquals('M local/modified-fs.txt\nM local/modified.txt\nA local/added.txt\nR local/deleted.txt\n! local/deleted-fs.txt\n', client.get_status(basepath=os.path.dirname(self.local_path)))
+        self.assertEquals('''\
+M local/modified-fs.txt
+M local/modified.txt
+A local/added.txt
+R local/deleted.txt
+! local/deleted-fs.txt
+'''.replace("/", os.path.sep), client.get_status(basepath=os.path.dirname(self.local_path)))
 
     def testStatusUntracked(self):
         client = HgClient(self.local_path)
         self.assertTrue(client.path_exists())
         self.assertTrue(client.detect_presence())
-        self.assertEquals('M modified-fs.txt\nM modified.txt\nA added.txt\nR deleted.txt\n! deleted-fs.txt\n? added-fs.txt\n', client.get_status(untracked=True))
+        self.assertEquals('''\
+M modified-fs.txt
+M modified.txt
+A added.txt
+R deleted.txt
+! deleted-fs.txt
+? added-fs.txt
+''', client.get_status(untracked=True))
 
     def test_hg_diff_path_change_None(self):
         from vcstools.hg import _hg_diff_path_change
@@ -378,13 +443,14 @@ class HGRemoteFetchTest(HGClientTestSetups):
         self.assertEqual(client.get_remote_version(fetch=True), self.local_version)
         self.assertEqual(client.get_version(), self.local_version)
 
+        subprocess.check_call("hg checkout default", shell=True, cwd=self.remote_path)
+        _touch(os.path.join(self.remote_path, "remote_new.txt"))
+
         for cmd in [
-                "hg checkout default",
-                "touch remote_new.txt",
                 "hg add remote_new.txt",
                 "hg commit -m remote_new"]:
             subprocess.check_call(cmd, shell=True, cwd=self.remote_path)
-        po = subprocess.Popen("hg log --template '{node|short}' -l1", shell=True, cwd=self.remote_path, stdout=subprocess.PIPE)
+        po = subprocess.Popen("hg log --template \"{node|short}\" -l1", shell=True, cwd=self.remote_path, stdout=subprocess.PIPE)
         remote_new_version = po.stdout.read().decode('UTF-8').rstrip("'").lstrip("'")
         self.assertNotEqual(self.local_version, remote_new_version)
 
@@ -443,8 +509,7 @@ class HGGetBranchesClientTest(HGClientTestSetups):
         # Make a remote branch
         subprocess.check_call('hg branch remote_branch', shell=True,
                               cwd=self.remote_path, stdout=subprocess.PIPE)
-        subprocess.check_call("touch fixed.txt", shell=True,
-                              cwd=self.remote_path)
+        _touch(os.path.join(self.remote_path, "fixed.txt"))
         subprocess.check_call("hg add fixed.txt", shell=True,
                               cwd=self.remote_path)
         subprocess.check_call("hg commit -m initial", shell=True,

--- a/test/test_tar.py
+++ b/test/test_tar.py
@@ -36,12 +36,14 @@ import os
 import unittest
 import tarfile
 import tempfile
-import shutil
 import subprocess
+import sys
 import mock
 
+from vcstools.common import rmtree
 from vcstools.tar import TarClient
 from test.mock_server import start_mock_server
+from .util import _touch
 
 def tarfile_contents():
     '''
@@ -62,7 +64,7 @@ def tarfile_contents():
 
     with open(filename, mode='rb') as file: # b is important -> binary
         result = file.read()
-    shutil.rmtree(tar_directory)
+    rmtree(tar_directory)
     return result
 
 
@@ -82,7 +84,7 @@ class TarClientTest(unittest.TestCase):
     def tearDown(self):
         for d in self.directories:
             self.assertTrue(os.path.exists(self.directories[d]))
-            shutil.rmtree(self.directories[d])
+            rmtree(self.directories[d])
             self.assertFalse(os.path.exists(self.directories[d]))
 
     def test_get_url_by_reading(self):
@@ -190,10 +192,10 @@ class TarClientTestLocal(unittest.TestCase):
         os.makedirs(self.version_path1)
         os.makedirs(self.version_path2)
 
-        subprocess.check_call("touch stack0.xml", shell=True, cwd=self.version_path0)
-        subprocess.check_call("touch stack.xml", shell=True, cwd=self.version_path1)
-        subprocess.check_call("touch stack1.xml", shell=True, cwd=self.version_path2)
-        subprocess.check_call("touch version1.txt", shell=True, cwd=self.root_directory)
+        _touch(os.path.join(self.version_path0, "stack0.xml"))
+        _touch(os.path.join(self.version_path1, "stack.xml"))
+        _touch(os.path.join(self.version_path2, "stack1.xml"))
+        _touch(os.path.join(self.root_directory, "version1.txt"))
 
         self.tar_url = os.path.join(self.root_directory, "origin.tar")
         self.tar_url_compressed = os.path.join(self.root_directory,
@@ -215,7 +217,7 @@ class TarClientTestLocal(unittest.TestCase):
     def tearDown(self):
         for d in self.directories:
             self.assertTrue(os.path.exists(self.directories[d]))
-            shutil.rmtree(self.directories[d])
+            rmtree(self.directories[d])
             self.assertFalse(os.path.exists(self.directories[d]))
 
     def test_checkout_version_local(self):

--- a/test/util.py
+++ b/test/util.py
@@ -1,0 +1,39 @@
+import os
+import urllib
+
+def _touch(path):
+    """
+    a portable way to create a file for test code.
+    """
+    with open(path, 'a'):
+        os.utime(path, None)
+
+
+def _pathname2url(pathname):
+    """
+    pathname2url shim helper for Python2\3
+    """
+    if (hasattr(urllib, 'pathname2url')):
+        from urllib import pathname2url
+    else:
+        from urllib.request import pathname2url
+    return pathname2url(pathname)
+
+
+def _urljoin(base, url):
+    """
+    urljoin shim helper for Python2\3
+    """
+    if (hasattr(urllib, 'parse')):
+        from urllib.parse import urljoin
+    else:
+        import urlparse
+        from urlparse import urljoin
+    return urljoin(base, url)
+
+
+def _get_file_uri(pathname):
+    """
+    return a normalized file: procotol uri by an absolute local file path
+    """
+    return _urljoin('file:', _pathname2url(pathname))


### PR DESCRIPTION
This is a change to initially bring up vcstools for Windows, and I am mainly focused on git related functionality. Here is a summary of changes:

- Add a portable touch() for test code to create test files.
- Fix rmtree cannot remove read-only files on Windows.
- Use forward slashes for git submodule. That's what Git expects for every OS.
- Use realpath as a substitute for the readlink on Windows. (os.readlink doesn't exist for Python on Windows)
- Explicitly convert string to str type when being passed to os.environ to avoid exception caused by unicode.
- Fix ^ character escape issue in Windows shell in _rev_list_contains()
- Fix line split issues and use forward slashes in _git_diff_path_submodule_change() since git diff is using forward slashes even on Windows.
- Add AppVeyor.yml for CI on Windows.