### PR TITLE
fixes wstool (Python3) "Tarball download unpack failed" problem

### DIFF
--- a/src/vcstools/common.py
+++ b/src/vcstools/common.py
@@ -120,7 +120,7 @@ def urlretrieve_netrc(url, filename=None):
             fdesc, fname = tempfile.mkstemp()
             fhand = os.fdopen(fdesc, "wb")
             # Copy the http response to the temporary file.
-        shutil.copyfileobj(resp.fp, fhand)
+        shutil.copyfileobj(resp, fhand)
     finally:
         if fhand:
             fhand.close()


### PR DESCRIPTION
error messages look like this:
ERROR [vcstools] Tarball download unpack failed: file could not be opened successfully[/vcstools]

shutil.copyfileobj accepts file-like objects with read() and write()
implemented. http.client.HTTPResponse (type of resp) already has read()

the use "resp.fp" is not only unnecessary, but causes extra bytes appear
in the front of "fhand" which led to the error above