### PR TITLE
Hack to get around GitHub playing with TAR

### DIFF
--- a/src/vcstools/tar.py
+++ b/src/vcstools/tar.py
@@ -46,6 +46,7 @@ import shutil
 import tarfile
 import sys
 import yaml
+import re
 from vcstools.vcs_base import VcsClientBase, VcsError
 from vcstools.common import urlretrieve_netrc, ensure_dir_notexists
 
@@ -117,8 +118,9 @@ class TarClient(VcsClientBase):
                 # relative path
                 subdirs = []
                 members = []
+                unversioned = re.sub(r'-[0-9.-]+$', '', version)
                 for m in temp_tarfile.getmembers():
-                    if m.name.startswith(version + '/'):
+                    if m.name.startswith(version + '/') or m.name.startswith(unversioned + '/'):
                         members.append(m)
                     if m.name.split('/')[0] not in subdirs:
                         subdirs.append(m.name.split('/')[0])


### PR DESCRIPTION
For whatever reason, GitHub randomly removes the version string from
the root directory of downloaded TAR files.

Try to address this by having both a versioned and an unversioned name
for the root directory, and if either match, accept that.

A fuller solution might add a "unversioned" parameter to checkout() so
we can turn this feature on and off, but that is a task for another day.