### PR TITLE
Stop using threading.Thread.isAlive

### DIFF
--- a/src/vcstools/common.py
+++ b/src/vcstools/common.py
@@ -319,7 +319,7 @@ def run_shell_command(cmd, cwd=None, shell=False, us_env=True,
                                  args=[proc, no_filter, verbose, show_stdout, q])
             t.start()
             t.join(timeout)
-            if t.isAlive():
+            if t.is_alive():
                 if hasattr(os.sys, 'winver'):
                     os.kill(proc.pid, signal.CTRL_BREAK_EVENT)
                 else:


### PR DESCRIPTION
The `is_alive` spelling was added in 2.6. The old `isAlive` spelling is completely undocumented in Python 3, was deprecated in 3.8, and was dropped in 3.9.

https://docs.python.org/2.7/library/threading.html#threading.Thread.isAlive
https://bugs.python.org/issue37804