### PR TITLE
Conditionally pin PyYAML back on python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - sudo apt-get install -qq python-yaml python-dateutil
   - sudo apt-get install -qq python3-yaml python3-dateutil
   - sudo apt-get install -qq git mercurial bzr subversion
-  - pip install setuptools tox tox-travis
+#  - pip install setuptools tox tox-travis
   - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then python -m pip install PyYAML==5.2; fi # Forcing PyYAML 5.2 while we retain Python 3.4 support PyYAML 5.3 and higher does not support Python 3.4
   - echo $PYTHONPATH
   - python -c 'import sys;print(sys.path)'
@@ -22,7 +22,7 @@ install:
   - svn --version
 # command to run tests
 script:
-  - tox
+  - python setup.py test
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - sudo apt-get install -qq python-yaml python-dateutil
   - sudo apt-get install -qq python3-yaml python3-dateutil
   - sudo apt-get install -qq git mercurial bzr subversion
-  - pip install -U setuptools tox tox-travis
+  - pip install setuptools tox tox-travis
   - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then python -m pip install PyYAML==5.2; fi # Forcing PyYAML 5.2 while we retain Python 3.4 support PyYAML 5.3 and higher does not support Python 3.4
   - echo $PYTHONPATH
   - python -c 'import sys;print(sys.path)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
+  - "3.4"   # When support for 3.4 is removed unpin the PyYAML version below.
   - "3.5"
   - "3.6"
 before_install:
@@ -12,6 +12,7 @@ install:
   - sudo apt-get install -qq python3-yaml python3-dateutil
   - sudo apt-get install -qq git mercurial bzr subversion
   - pip install -U setuptools tox tox-travis
+  - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then python -m pip install PyYAML==5.2; fi # Forcing PyYAML 5.2 while we retain Python 3.4 support PyYAML 5.3 and higher does not support Python 3.4
   - echo $PYTHONPATH
   - python -c 'import sys;print(sys.path)'
   - python setup.py install

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # While tox can be configured to do plenty of things, it is bothersome to work with quickly, and it is not a lightweight dependency, so prefer to write build logic in setup.py or other commands that run without tox.
 
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py35, py36
 
 [testenv]
 # flawed due to https://github.com/tox-dev/tox/issues/149


### PR DESCRIPTION
The latest version is no longer backwards compatible.

This is following the pattern we've used elsewhere such as: https://github.com/ros-infrastructure/rosdep/pull/739